### PR TITLE
Add Arduino sketch to clear EEPROM memory

### DIFF
--- a/limpar_eeprom.ino
+++ b/limpar_eeprom.ino
@@ -1,0 +1,18 @@
+#include <EEPROM.h>
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial) {
+    ;
+  }
+
+  Serial.println(F("Iniciando limpeza completa da EEPROM..."));
+  for (int endereco = 0; endereco < EEPROM.length(); endereco++) {
+    EEPROM.write(endereco, 0xFF);
+  }
+  Serial.println(F("EEPROM apagada (todos os bytes = 0xFF)."));
+}
+
+void loop() {
+  // Nada a fazer no loop principal.
+}


### PR DESCRIPTION
## Summary
- add a dedicated sketch that writes 0xFF to every EEPROM address to guarantee a clean state
- provide basic serial feedback while the wipe runs and completes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1da839bb08326887d993105123442